### PR TITLE
Step 05a: Relation module refactor

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -32,4 +32,5 @@ test {
     _ = @import("relation.zig");
     _ = @import("fact_fetcher.zig");
     _ = @import("bitmap_ingest.zig");
+    _ = @import("test_helpers.zig");
 }

--- a/src/relation.zig
+++ b/src/relation.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const lmdb = @import("lmdb");
 const rawr = @import("rawr");
 const RoaringBitmap = rawr.RoaringBitmap;
 
@@ -150,9 +151,245 @@ pub const Relation = union(enum) {
     }
 };
 
+pub const RelationMap = std.StringHashMapUnmanaged(Relation);
+
+/// Free all relations in a RelationMap, including duped predicate keys.
+pub fn deinitRelations(relations: *RelationMap, allocator: std.mem.Allocator) void {
+    var iter = relations.iterator();
+    while (iter.next()) |entry| {
+        allocator.free(@constCast(entry.key_ptr.*));
+        entry.value_ptr.deinit();
+    }
+    relations.deinit(allocator);
+}
+
+/// Persist all relations to the LMDB "bitmaps" database.
+pub fn persistRelations(
+    relations: *RelationMap,
+    env: lmdb.Environment,
+    allocator: std.mem.Allocator,
+) !void {
+    const txn = try env.transaction(.{ .mode = .ReadWrite });
+    errdefer txn.abort();
+
+    const bm_db = try txn.database("bitmaps", .{ .create = true });
+
+    var rel_iter = relations.iterator();
+    while (rel_iter.next()) |entry| {
+        const pred = entry.key_ptr.*;
+        switch (entry.value_ptr.*) {
+            .binary => |*bin| {
+                // Domain
+                try putBitmap(bm_db, pred, "domain", null, &bin.domain, allocator);
+                // Range
+                try putBitmap(bm_db, pred, "range", null, &bin.range, allocator);
+                // Forward entries
+                var fwd_iter = bin.forward.iterator();
+                while (fwd_iter.next()) |fwd_entry| {
+                    try putBitmap(bm_db, pred, "fwd", fwd_entry.key_ptr.*, fwd_entry.value_ptr, allocator);
+                }
+                // Reverse entries
+                var rev_iter = bin.reverse.iterator();
+                while (rev_iter.next()) |rev_entry| {
+                    try putBitmap(bm_db, pred, "rev", rev_entry.key_ptr.*, rev_entry.value_ptr, allocator);
+                }
+            },
+            .unary => |*un| {
+                try putBitmap(bm_db, pred, "members", null, &un.members, allocator);
+            },
+        }
+    }
+
+    try txn.commit();
+}
+
+/// Load all relations from the LMDB "bitmaps" database.
+/// Returns empty map if database does not exist (first run).
+pub fn loadRelations(
+    env: lmdb.Environment,
+    allocator: std.mem.Allocator,
+) !RelationMap {
+    var relations: RelationMap = .{};
+    errdefer deinitRelations(&relations, allocator);
+
+    const txn = try env.transaction(.{ .mode = .ReadOnly });
+    defer txn.abort();
+
+    const bm_db = txn.database("bitmaps", .{}) catch |err| switch (err) {
+        error.MDB_NOTFOUND => return relations,
+        else => return err,
+    };
+
+    var cursor = try bm_db.cursor();
+    defer cursor.deinit();
+
+    // Iterate all entries
+    _ = try cursor.goToFirst() orelse return relations;
+
+    while (true) {
+        const entry = try cursor.getCurrentEntry();
+        try loadBitmapEntry(&relations, entry.key, entry.value, allocator);
+        _ = try cursor.goToNext() orelse break;
+    }
+
+    return relations;
+}
+
+/// Serialize a bitmap and store it in LMDB.
+fn putBitmap(
+    db: anytype,
+    pred: []const u8,
+    component: []const u8,
+    entity_id: ?u32,
+    bitmap: *rawr.RoaringBitmap,
+    allocator: std.mem.Allocator,
+) !void {
+    // Build key: "pred\x00component[\x00{u32_be}]"
+    var key_buf: [512]u8 = undefined;
+    var pos: usize = 0;
+    @memcpy(key_buf[pos..][0..pred.len], pred);
+    pos += pred.len;
+    key_buf[pos] = 0;
+    pos += 1;
+    @memcpy(key_buf[pos..][0..component.len], component);
+    pos += component.len;
+
+    if (entity_id) |eid| {
+        key_buf[pos] = 0;
+        pos += 1;
+        const be_bytes = std.mem.toBytes(std.mem.nativeToBig(u32, eid));
+        @memcpy(key_buf[pos..][0..4], &be_bytes);
+        pos += 4;
+    }
+
+    const key = key_buf[0..pos];
+
+    // Serialize bitmap
+    const bytes = try bitmap.serialize(allocator);
+    defer allocator.free(bytes);
+
+    try db.set(key, bytes);
+}
+
+/// Parse a single LMDB entry from the "bitmaps" database and insert into the relation map.
+fn loadBitmapEntry(
+    relations: *RelationMap,
+    key: []const u8,
+    value: []const u8,
+    allocator: std.mem.Allocator,
+) !void {
+    // Parse key: split on \x00
+    // key[0..first_null] = predicate
+    // key[first_null+1..second_null or end] = component
+    // key[second_null+1..] = optional entity_id (4 bytes, big-endian)
+
+    const first_null = std.mem.indexOfScalar(u8, key, 0) orelse return;
+    const pred = key[0..first_null];
+    const rest = key[first_null + 1 ..];
+
+    const second_null = std.mem.indexOfScalar(u8, rest, 0);
+    const component = if (second_null) |sn| rest[0..sn] else rest;
+    const entity_id: ?u32 = if (second_null) |sn| blk: {
+        if (rest[sn + 1 ..].len >= 4) {
+            break :blk std.mem.bigToNative(u32, std.mem.bytesToValue(u32, rest[sn + 1 ..][0..4]));
+        }
+        break :blk null;
+    } else null;
+
+    // Ensure relation exists -- IMPORTANT: dupe pred before getOrPut (cursor key lifetime)
+    const owned_pred = try allocator.dupe(u8, pred);
+    const gop = try relations.getOrPut(allocator, owned_pred);
+    if (!gop.found_existing) {
+        // Determine arity from component name
+        if (std.mem.eql(u8, component, "members")) {
+            gop.value_ptr.* = .{ .unary = try UnaryRelation.init(allocator) };
+        } else {
+            gop.value_ptr.* = .{ .binary = try BinaryRelation.init(allocator) };
+        }
+    } else {
+        // Key already existed -- free the dupe we just made
+        allocator.free(owned_pred);
+    }
+
+    // Deserialize bitmap and assign to the right field
+    var bitmap = try rawr.RoaringBitmap.deserialize(allocator, value);
+
+    if (std.mem.eql(u8, component, "members")) {
+        gop.value_ptr.unary.members.deinit();
+        gop.value_ptr.unary.members = bitmap;
+    } else if (std.mem.eql(u8, component, "domain")) {
+        gop.value_ptr.binary.domain.deinit();
+        gop.value_ptr.binary.domain = bitmap;
+    } else if (std.mem.eql(u8, component, "range")) {
+        gop.value_ptr.binary.range.deinit();
+        gop.value_ptr.binary.range = bitmap;
+    } else if (std.mem.eql(u8, component, "fwd")) {
+        const eid = entity_id orelse {
+            bitmap.deinit();
+            return;
+        };
+        try gop.value_ptr.binary.forward.put(allocator, eid, bitmap);
+    } else if (std.mem.eql(u8, component, "rev")) {
+        const eid = entity_id orelse {
+            bitmap.deinit();
+            return;
+        };
+        try gop.value_ptr.binary.reverse.put(allocator, eid, bitmap);
+    } else {
+        bitmap.deinit(); // unknown component, discard
+    }
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
+
+const test_helpers = @import("test_helpers.zig");
+const createTempLmdbEnv = test_helpers.createTempLmdbEnv;
+const destroyTempLmdbEnv = test_helpers.destroyTempLmdbEnv;
+
+test "persist and load relations roundtrip" {
+    const allocator = std.testing.allocator;
+
+    var state = try createTempLmdbEnv(allocator);
+    defer destroyTempLmdbEnv(&state, allocator);
+
+    // Build and persist
+    {
+        var relations: RelationMap = .{};
+        defer deinitRelations(&relations, allocator);
+
+        // Create a binary relation with some data
+        const pred = try allocator.dupe(u8, "influenced_by");
+        try relations.put(allocator, pred, .{ .binary = try BinaryRelation.init(allocator) });
+        var bin = &relations.getPtr("influenced_by").?.binary;
+        try bin.insert(0, 1);
+        try bin.insert(0, 2);
+        try bin.insert(3, 1);
+
+        try persistRelations(&relations, state.env, allocator);
+    }
+
+    // Load into fresh map
+    {
+        var relations = try loadRelations(state.env, allocator);
+        defer deinitRelations(&relations, allocator);
+
+        const rel = relations.get("influenced_by") orelse return error.RelationNotFound;
+        const bin = rel.binary;
+
+        try std.testing.expect(bin.contains(0, 1));
+        try std.testing.expect(bin.contains(0, 2));
+        try std.testing.expect(bin.contains(3, 1));
+        try std.testing.expect(!bin.contains(1, 0));
+
+        // Check domain/range
+        try std.testing.expect(bin.domain.contains(0));
+        try std.testing.expect(bin.domain.contains(3));
+        try std.testing.expect(bin.range.contains(1));
+        try std.testing.expect(bin.range.contains(2));
+    }
+}
 
 test "binary relation insert and contains" {
     var rel = try BinaryRelation.init(std.testing.allocator);

--- a/src/test_helpers.zig
+++ b/src/test_helpers.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const lmdb = @import("lmdb");
+
+pub fn createTempLmdbEnv(allocator: std.mem.Allocator) !struct { env: lmdb.Environment, path: [:0]const u8 } {
+    const random = std.crypto.random.int(u64);
+    const path = try std.fmt.allocPrint(allocator, "/tmp/kb-bitmap-test-{x}", .{random});
+    const path_z = try allocator.realloc(path, path.len + 1);
+    path_z[path.len] = 0;
+    const path_sentinel = path_z[0..path.len :0];
+
+    std.fs.makeDirAbsolute(path_sentinel) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+
+    const env = try lmdb.Environment.init(path_sentinel, .{ .max_dbs = 8 });
+    return .{ .env = env, .path = path_sentinel };
+}
+
+pub fn destroyTempLmdbEnv(state: anytype, allocator: std.mem.Allocator) void {
+    state.env.deinit();
+    std.fs.deleteTreeAbsolute(state.path) catch {};
+    allocator.free(state.path);
+}


### PR DESCRIPTION
## Summary

Pure code motion refactor -- no new behavior, no new logic.

- Move `RelationMap`, `deinitRelations`, `persistRelations`, `loadRelations`, `putBitmap`, `loadBitmapEntry` from `bitmap_ingest.zig` to `relation.zig`
- Move "persist and load relations roundtrip" test to `relation.zig`
- Extract `createTempLmdbEnv`, `destroyTempLmdbEnv` to new `src/test_helpers.zig`
- `bitmap_ingest.zig` re-exports moved symbols so its public API is unchanged
- Add `lmdb` import to `relation.zig`
- Add `test_helpers.zig` to `lib.zig` test block

## Test plan

- [x] `zig build test` -- all existing tests pass, zero test code changes
- [x] `zig build test-all` -- zero regressions
- [x] No changes to `string_interner.zig`, `fact_fetcher.zig`, `datalog.zig`, `main.zig`

Closes #3