### PR TITLE
Update README and add demo fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A hypergraph fact store with Datalog queries, backed by LMDB and roaring bitmaps
 Everything is stored as **facts** — hyperedges connecting typed entities:
 
 ```json
-{"edges": [["author", "Homer"], ["book", "The Iliad"], ["rel", "wrote"]], "source": "library"}
+{"edges": [["player", "Alice"], ["team", "Rockets"], ["rel", "plays_for"]], "source": "league"}
 ```
 
 Query from any angle:
 ```bash
-kb get author/Homer          # What did Homer write?
-kb get book/The\ Iliad       # Who wrote The Iliad?
-kb get rel/wrote             # All author-book relationships
+kb get player/Alice          # What team is Alice on?
+kb get team/Rockets          # Who plays for the Rockets?
+kb get rel/plays_for         # All player-team relationships
 ```
 
 ## Install
@@ -27,7 +27,7 @@ zig build   # Requires Zig 0.15.2
 
 ```bash
 kb ingest data.jsonl          # Load facts from JSONL
-kb get author/                # Browse entities
+kb get team/                  # Browse entities
 kb datalog rules.dl           # Run Datalog rules and queries
 ```
 
@@ -36,13 +36,13 @@ kb datalog rules.dl           # Run Datalog rules and queries
 Each fact connects multiple typed entities as a hyperedge. The store indexes every entity for fast lookups from any direction.
 
 ```json
-{"edges": [["author", "Virgil"], ["author", "Homer"], ["rel", "influenced"]], "source": "library"}
+{"edges": [["team", "Wolves"], ["team", "Rockets"], ["rel", "won"]], "source": "league"}
 ```
 
 Use `@map` directives in `.dl` files to bridge hypergraph facts into Datalog predicates:
 ```prolog
-@map wrote(A, B) = [rel:wrote, author:A, book:B].
-@map influenced(A, B) = [rel:influenced, author:A, author:B].
+@map plays_for(P, T) = [rel:plays_for, player:P, team:T].
+@map won(W, L) = [rel:won, team:W, team:L].
 ```
 
 ## Language Features
@@ -52,16 +52,16 @@ kb uses Datalog — a declarative language where you define rules that derive ne
 ### Rules and recursion
 
 ```prolog
-influenced("Homer", "Virgil").
-influenced("Virgil", "Dante").
+won("Wolves", "Rockets").
+won("Bears", "Wolves").
 
 % Direct rule
-tradition(X, Y) :- influenced(X, Y).
+dominates(A, B) :- won(A, B).
 
 % Recursive — finds the full chain no matter how deep
-tradition(X, Z) :- influenced(X, Y), tradition(Y, Z).
+dominates(A, C) :- won(A, B), dominates(B, C).
 
-?- tradition("Homer", X).   % X = Virgil, X = Dante
+?- dominates("Bears", X).   % X = Wolves, X = Rockets
 ```
 
 ### Wildcards
@@ -69,7 +69,7 @@ tradition(X, Z) :- influenced(X, Y), tradition(Y, Z).
 Use `_` to ignore a position. Each `_` is independent.
 
 ```prolog
-has_connections(S) :- connection(S, _).   % any server that connects somewhere
+has_roster(T) :- plays_for(_, T).   % any team with at least one player
 ```
 
 ### Stratified negation

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # kb
 
-A hypergraph-based fact store with Datalog queries.
+A hypergraph fact store with Datalog queries, backed by LMDB and roaring bitmaps.
 
 ## Core Idea
 
-Everything is stored as **facts** — hyperedges connecting multiple typed entities.
+Everything is stored as **facts** — hyperedges connecting typed entities:
 
 ```json
-{"edges": [["author", "george"], ["book", "1984"], ["rel", "wrote"]], "source": "library"}
-{"edges": [["author", "george"], ["book", "animal_farm"], ["rel", "wrote"]], "source": "library"}
+{"edges": [["author", "Homer"], ["book", "The Iliad"], ["rel", "wrote"]], "source": "library"}
 ```
 
 Query from any angle:
 ```bash
-kb get author/george         # What did george write?
-kb get book/1984             # Who wrote 1984?
+kb get author/Homer          # What did Homer write?
+kb get book/The\ Iliad       # Who wrote The Iliad?
 kb get rel/wrote             # All author-book relationships
 ```
 
@@ -27,86 +26,103 @@ zig build   # Requires Zig 0.15.2
 ## Usage
 
 ```bash
-# Ingest facts from JSONL
-kb ingest data.jsonl
-
-# Query entities
-kb get author/
-kb get author/george
-kb get author/george/book/
-
-# Run Datalog rules
-kb datalog rules.dl
-```
-
-## Datalog
-
-Define rules over the hypergraph using `@map` directives:
-
-```prolog
-% Map hypergraph facts to predicates
-@map wrote(A, B) = [rel:wrote, author:A, book:B].
-
-% Define derived relationships
-influenced_by(A, C) :- wrote(A, B), references(B, C).
-
-% Query
-?- influenced_by(A, C).
+kb ingest data.jsonl          # Load facts from JSONL
+kb get author/                # Browse entities
+kb datalog rules.dl           # Run Datalog rules and queries
 ```
 
 ## Fact Format
 
+Each fact connects multiple typed entities as a hyperedge. The store indexes every entity for fast lookups from any direction.
+
 ```json
-{
-  "edges": [["author", "Virgil"], ["author", "Homer"], ["rel", "influenced"]],
-  "source": "library"
-}
+{"edges": [["author", "Virgil"], ["author", "Homer"], ["rel", "influenced"]], "source": "library"}
 ```
 
-Each fact connects multiple typed entities. The hypergraph indexes by entity for fast lookups from any direction.
+Use `@map` directives in `.dl` files to bridge hypergraph facts into Datalog predicates:
+```prolog
+@map wrote(A, B) = [rel:wrote, author:A, book:B].
+@map influenced(A, B) = [rel:influenced, author:A, author:B].
+```
+
+## Language Features
+
+kb uses Datalog — a declarative language where you define rules that derive new facts from existing ones. The engine applies rules repeatedly until no new facts are derived (fixpoint).
+
+### Rules and recursion
+
+```prolog
+influenced("Homer", "Virgil").
+influenced("Virgil", "Dante").
+
+% Direct rule
+tradition(X, Y) :- influenced(X, Y).
+
+% Recursive — finds the full chain no matter how deep
+tradition(X, Z) :- influenced(X, Y), tradition(Y, Z).
+
+?- tradition("Homer", X).   % X = Virgil, X = Dante
+```
+
+### Wildcards
+
+Use `_` to ignore a position. Each `_` is independent.
+
+```prolog
+has_connections(S) :- connection(S, _).   % any server that connects somewhere
+```
+
+### Stratified negation
+
+`not` filters out bindings where a fact exists. Variables in negated atoms must appear in a positive atom in the same rule (safety requirement). Rules with negation are automatically stratified.
+
+```prolog
+loser(T) :- won(_, T).
+unbeaten(T) :- team(T), not loser(T).
+```
+
+### Comparison operators
+
+`=`, `!=`, `<`, `>`, `<=`, `>=` filter bindings without generating new facts. Both sides must be bound by a positive atom. Numeric when both values parse as integers, lexicographic otherwise.
+
+```prolog
+high_scorer(P) :- points(P, Pts), Pts >= "20".
+mid_range(P)   :- points(P, Pts), Pts >= "10", Pts < "20".
+rivals(A, B)   :- won(A, B), A != B.
+```
+
+### Putting it together
+
+A complete example combining all features — see `tests/fixtures/demo.dl`:
+
+```prolog
+% Facts
+plays_for("Alice", "Rockets").  plays_for("Carol", "Wolves").
+points("Alice", "28").          points("Carol", "35").
+won("Wolves", "Rockets").       won("Bears", "Wolves").
+
+% Recursive dominance
+dominates(A, B) :- won(A, B).
+dominates(A, C) :- won(A, B), dominates(B, C).
+
+% Negation: teams with no losses
+loser(T) :- won(_, T).
+unbeaten(T) :- team(T), not loser(T).
+
+% Comparisons + recursion: high scorers on dominant teams
+high_on_team(P, T) :- points(P, Pts), Pts >= "20", plays_for(P, T).
+top_threat(P) :- high_on_team(P, T), dominates(T, "Rockets").
+
+?- top_threat(P).   % Carol (Wolves dominate Rockets, Carol scored 35)
+```
+
+## Evaluation
+
+Rules are evaluated using a bitmap-based semi-naive engine. Relations are stored as roaring bitmap sets, and joins are computed via bitmap intersection. Stratification handles negation by partitioning rules into layers evaluated in dependency order.
 
 ## Storage
 
-Uses LMDB for memory-mapped, concurrent-read storage. Data persists in `.kb/` directory.
-
-## How Datalog Works
-
-Datalog is a declarative query language where you define **rules** that derive new facts from existing ones.
-
-**Facts** are things you know:
-```prolog
-influenced("Virgil", "Homer").   % Virgil was influenced by Homer
-influenced("Dante", "Virgil").   % Dante was influenced by Virgil
-```
-
-**Rules** derive new facts:
-```prolog
-influenced_by(A, C) :- influenced(A, B), influenced(B, C).
-```
-
-This reads: "A is influenced by C **if** A is influenced by B **and** B is influenced by C."
-
-**Evaluation** repeatedly applies rules until no new facts are derived:
-```
-Start:    influenced(Virgil,Homer), influenced(Dante,Virgil)
-Apply:    influenced_by(Dante,Homer)  ← new fact derived!
-Apply:    (no more new facts)
-Done.
-```
-
-**Queries** ask what's true:
-```prolog
-?- influenced_by(X, "Homer").   % Who was influenced by Homer?
-   X = Dante
-```
-
-The power is in **recursive rules** — finding transitive relationships:
-```prolog
-tradition(X, Y) :- influenced(X, Y).
-tradition(X, Z) :- influenced(X, Y), tradition(Y, Z).
-```
-
-This finds all authors in a literary tradition, no matter how many generations back. The engine keeps applying rules until it reaches a fixpoint (no new facts). You describe *what* you want, not *how* to compute it.
+LMDB provides memory-mapped, concurrent-read storage. Data persists in the `.kb/` directory.
 
 ## License
 

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -128,6 +128,81 @@ else
     echo "  OK: unstratifiable program rejected"
 fi
 
+# Test 8: Wildcards
+echo ""
+echo "--- Test: Wildcards ---"
+WC_DL=$(mktemp /tmp/kb-test-XXXXXX.dl)
+cat > "$WC_DL" << 'EOF'
+edge("a", "b"). edge("b", "c"). edge("c", "d").
+has_outgoing(X) :- edge(X, _).
+has_incoming(X) :- edge(_, X).
+?- has_outgoing(X).
+?- has_incoming(X).
+EOF
+OUTPUT=$(cd /tmp && "$KB" datalog "$WC_DL" 2>&1)
+assert_contains "$OUTPUT" "has_outgoing(X)" "wildcard query ran"
+assert_contains "$OUTPUT" "X = a" "a has outgoing"
+assert_contains "$OUTPUT" "X = b" "b has outgoing"
+assert_contains "$OUTPUT" "X = c" "c has outgoing"
+assert_contains "$OUTPUT" "X = d" "d has incoming"
+rm -f "$WC_DL"
+
+# Test 9: Comparisons
+echo ""
+echo "--- Test: Comparisons ---"
+CMP_DL=$(mktemp /tmp/kb-test-XXXXXX.dl)
+cat > "$CMP_DL" << 'EOF'
+score("alice", "90"). score("bob", "40"). score("carol", "75"). score("dave", "10").
+high(X) :- score(X, S), S > "50".
+low(X) :- score(X, S), S <= "20".
+exact(X) :- score(X, S), S = "75".
+not_bob(X) :- score(X, _), X != "bob".
+mid(X) :- score(X, S), S >= "40", S < "80".
+?- high(X).
+?- low(X).
+?- exact(X).
+?- not_bob(X).
+?- mid(X).
+EOF
+OUTPUT=$(cd /tmp && "$KB" datalog "$CMP_DL" 2>&1)
+assert_contains "$OUTPUT" "high(X)" "gt query ran"
+assert_contains "$OUTPUT" "X = alice" "alice is high scorer"
+assert_contains "$OUTPUT" "X = carol" "carol is high scorer"
+assert_contains "$OUTPUT" "low(X)" "le query ran"
+assert_contains "$OUTPUT" "X = dave" "dave is low scorer"
+assert_contains "$OUTPUT" "exact(X)" "eq query ran"
+assert_contains "$OUTPUT" "X = carol" "carol exact 75"
+assert_contains "$OUTPUT" "not_bob(X)" "neq query ran"
+assert_contains "$OUTPUT" "mid(X)" "range query ran"
+assert_contains "$OUTPUT" "X = bob" "bob in mid range"
+rm -f "$CMP_DL"
+
+# Test 10: Combined demo (recursion + wildcards + negation + comparisons)
+echo ""
+echo "--- Test: Combined demo ---"
+OUTPUT=$(cd /tmp && "$KB" datalog "$FIXTURES/demo.dl" 2>&1)
+# High scorers: 20+ points
+assert_contains "$OUTPUT" "high_scorer(P)" "high_scorer query ran"
+assert_contains "$OUTPUT" "P = Alice" "Alice is high scorer"
+assert_contains "$OUTPUT" "P = Grace" "Grace is high scorer"
+assert_contains "$OUTPUT" "(4 results)" "4 high scorers"
+# Mid scorers: 10-19 range
+assert_contains "$OUTPUT" "mid_scorer(P)" "mid_scorer query ran"
+assert_contains "$OUTPUT" "P = Bob" "Bob is mid scorer"
+assert_contains "$OUTPUT" "P = Hank" "Hank is mid scorer"
+# Dominance (recursion)
+assert_contains "$OUTPUT" "dominates" "dominates query ran"
+assert_contains "$OUTPUT" "X = Rockets" "Wolves dominate Rockets"
+assert_contains "$OUTPUT" "(1 results)" "1 dominance result for Wolves"
+# Negation: unbeaten teams
+assert_contains "$OUTPUT" "unbeaten(X)" "unbeaten query ran"
+assert_contains "$OUTPUT" "X = Falcons" "Falcons are unbeaten"
+# Combined: top threats (high scorers on teams dominating Rockets)
+assert_contains "$OUTPUT" "top_threat(P)" "top_threat query ran"
+assert_contains "$OUTPUT" "P = Carol" "Carol is a top threat"
+assert_contains "$OUTPUT" "P = Eve" "Eve is a top threat"
+assert_contains "$OUTPUT" "(3 results)" "3 top threats"
+
 # Clean up
 rm -rf "$TEST_DB"
 

--- a/tests/fixtures/demo.dl
+++ b/tests/fixtures/demo.dl
@@ -1,0 +1,67 @@
+% Sports league analysis
+% Demonstrates recursion, wildcards, comparisons, and negation together.
+
+% === Facts ===
+
+% Players and their teams
+plays_for("Alice", "Rockets").
+plays_for("Bob", "Rockets").
+plays_for("Carol", "Wolves").
+plays_for("Dave", "Wolves").
+plays_for("Eve", "Bears").
+plays_for("Frank", "Bears").
+plays_for("Grace", "Falcons").
+plays_for("Hank", "Falcons").
+
+% Points scored (season total)
+points("Alice", "28").
+points("Bob", "12").
+points("Carol", "35").
+points("Dave", "8").
+points("Eve", "22").
+points("Frank", "5").
+points("Grace", "40").
+points("Hank", "18").
+
+% Head-to-head results: won(winner, loser)
+won("Wolves", "Rockets").
+won("Bears", "Wolves").
+won("Falcons", "Bears").
+
+% Teams
+team("Rockets"). team("Wolves"). team("Bears"). team("Falcons").
+
+% === Rules ===
+
+% Wildcards: every team that has at least one player
+active_team(T) :- plays_for(_, T).
+
+% Comparisons: high scorers (20+ points)
+high_scorer(P) :- points(P, Pts), Pts >= "20".
+
+% Range: mid-range scorers (10-19 points)
+mid_scorer(P) :- points(P, Pts), Pts >= "10", Pts < "20".
+
+% Not-equal: rivals (different teams that played each other)
+rivals(A, B) :- won(A, B), A != B.
+
+% Recursion: transitive dominance chain
+dominates(A, B) :- won(A, B).
+dominates(A, C) :- won(A, B), dominates(B, C).
+
+% Negation: teams with no losses
+loser(T) :- won(_, T).
+unbeaten(T) :- team(T), not loser(T).
+
+% Combined: high scorers on teams that dominate the Rockets
+% We keep the points in the derived relation so downstream joins work.
+high_on_team(P, T) :- points(P, Pts), Pts >= "20", plays_for(P, T).
+top_threat(P) :- high_on_team(P, T), dominates(T, "Rockets").
+
+% === Queries ===
+
+?- high_scorer(P).
+?- mid_scorer(P).
+?- dominates("Wolves", X).
+?- unbeaten(X).
+?- top_threat(P).


### PR DESCRIPTION
## Summary
- Rewrites README Datalog section as a concise Language Features guide covering rules/recursion, wildcards, negation, and comparison operators (129 lines total)
- Adds `tests/fixtures/demo.dl` — a sports league analysis scenario that naturally exercises all four features (recursion for dominance chains, wildcards for roster queries, comparisons for scoring thresholds, negation for unbeaten teams)
- Adds 3 new e2e test sections: wildcards, comparisons (all 6 operators), and combined demo validation

## Test plan
- [x] `zig build test-all` — zero regressions
- [x] `bash tests/e2e.sh` — all 10 test sections pass (7 existing + 3 new)
- [x] No source code changes